### PR TITLE
List datasets in the COVID19 study-a-thon

### DIFF
--- a/HOWTO.md
+++ b/HOWTO.md
@@ -1,0 +1,8 @@
+After cloning this repo, you have to:
+```
+git submodule update --init --recursive
+brew install hugo
+hugo server
+```
+
+Add new pages with `hugo new content/dataset/dataset_name.md`

--- a/config/_default/menus.toml
+++ b/config/_default/menus.toml
@@ -24,6 +24,11 @@
   weight = 40
 
 [[main]]
+  name = "Datasets"
+  url = "#datasets"
+  weight = 50
+
+[[main]]
   name = "Contact"
   url = "#contact"
   weight = 60

--- a/content/dataset/ccae.md
+++ b/content/dataset/ccae.md
@@ -1,0 +1,31 @@
+---
+# Documentation: https://sourcethemes.com/academic/docs/managing-content/
+
+title: "CCAE"
+subtitle: "Commercial Claims and Encounters"
+summary: ""
+authors: []
+tags: []
+categories: []
+date: 2020-03-28T12:46:02+01:00
+lastmod: 2020-03-28T12:46:02+01:00
+featured: false
+draft: false
+
+# Featured image
+# To use, add an image named `featured.jpg/png` to your page's folder.
+# Focal points: Smart, Center, TopLeft, Top, TopRight, Left, Right, BottomLeft, Bottom, BottomRight.
+image:
+  caption: ""
+  focal_point: ""
+  preview_only: false
+
+# Projects (optional).
+#   Associate this post with one or more of your projects.
+#   Simply enter your project's folder or file name without extension.
+#   E.g. `projects = ["internal-project"]` references `content/project/deep-learning/index.md`.
+#   Otherwise, set `projects = []`.
+projects: []
+---
+
+Proin sit amet velit convallis, feugiat eros eu, volutpat mauris. Phasellus vehicula facilisis erat non condimentum. In finibus tortor nisi, vel mollis arcu porta non. Curabitur vulputate hendrerit ipsum eu auctor. Nam rhoncus nec metus condimentum imperdiet. Fusce a tellus nunc. Praesent lobortis ornare faucibus. Duis aliquet lacus sodales nibh vehicula, a lobortis mi fermentum. Nulla interdum felis consequat augue accumsan mattis. Nam vulputate ipsum eros, et aliquet tortor maximus a. Praesent eu augue magna. Phasellus faucibus mollis turpis, non vestibulum nisi mollis non.

--- a/content/dataset/hira.md
+++ b/content/dataset/hira.md
@@ -1,0 +1,31 @@
+---
+# Documentation: https://sourcethemes.com/academic/docs/managing-content/
+
+title: "HIRA"
+subtitle: "Health Insurance Review and Assessment Service"
+summary: ""
+authors: []
+tags: []
+categories: []
+date: 2020-03-28T12:49:43+01:00
+lastmod: 2020-03-28T12:49:43+01:00
+featured: false
+draft: false
+
+# Featured image
+# To use, add an image named `featured.jpg/png` to your page's folder.
+# Focal points: Smart, Center, TopLeft, Top, TopRight, Left, Right, BottomLeft, Bottom, BottomRight.
+image:
+  caption: ""
+  focal_point: ""
+  preview_only: false
+
+# Projects (optional).
+#   Associate this post with one or more of your projects.
+#   Simply enter your project's folder or file name without extension.
+#   E.g. `projects = ["internal-project"]` references `content/project/deep-learning/index.md`.
+#   Otherwise, set `projects = []`.
+projects: []
+---
+
+Sed interdum nisi id consequat lobortis. Nunc vel erat malesuada, commodo libero sed, suscipit sem. Sed a commodo ante. Maecenas nibh est, aliquet blandit arcu non, vestibulum lacinia felis. Praesent id risus at mi ultricies tristique eu vel est. Vestibulum sed pellentesque enim. In hac habitasse platea dictumst. Donec et ipsum et arcu gravida hendrerit. Quisque mollis fringilla est blandit laoreet. Sed pellentesque cursus efficitur. Phasellus lorem augue, vestibulum eget metus non, lacinia sollicitudin est. Vestibulum pretium placerat nunc, quis elementum ipsum aliquam vitae. Suspendisse congue, felis ut sagittis ornare, sapien enim suscipit risus, ut tristique augue diam non quam. Duis a velit ex. Maecenas imperdiet purus turpis, et efficitur nisl facilisis nec.

--- a/content/dataset/ipci/index.md
+++ b/content/dataset/ipci/index.md
@@ -1,0 +1,39 @@
+---
+title: IPCI
+subtitle: Integrated Primary Care Information
+summary: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum quis nibh quis est tempor convallis ut ac arcu. Fusce ultricies blandit varius. Duis laoreet ligula vitae tellus condimentum porta. Nunc ex tellus, gravida et imperdiet vitae, ultricies non massa. Praesent accumsan finibus purus et auctor. Integer faucibus sed odio sit amet gravida. Vivamus eleifend, est convallis scelerisque eleifend, risus augue suscipit augue, eu facilisis libero ipsum vel lorem. Nunc consectetur turpis et condimentum consectetur. Donec nec purus sit amet est efficitur cursus.'
+owner:
+  organisation: Erasmus Medical Center Rotterdam
+  lead: Peter Rijnbeek
+country: The Netherlands
+tags:
+- dataset
+date: "2020-03-28T00:00:00Z"
+author: maximmoinat
+
+# Optional external URL for project (replaces project detail page).
+external_link: ""
+
+image:
+  caption: Photo by rawpixel on Unsplash
+  focal_point: Smart
+
+links:
+- icon: globe
+  icon_pack: fas
+  name: OHDSI Forums discussion
+  url: https://forums.ohdsi.org/t/ohdsi-covid-19-review-on-the-effect-of-ace-inhibitors-and-angiotensin-receptor-blockers-on-covid-19-incidence-and-complication-rate/10071
+url_code: "https://github.com/ohdsi-studies/X"
+url_pdf: ""
+url_slides: ""
+url_video: ""
+
+# Slides (optional).
+#   Associate this project with Markdown slides.
+#   Simply enter your slide deck's filename without extension.
+#   E.g. `slides = "example-slides"` references `content/slides/example-slides.md`.
+#   Otherwise, set `slides = ""`.
+slides: example
+---
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum quis nibh quis est tempor convallis ut ac arcu. Fusce ultricies blandit varius. Duis laoreet ligula vitae tellus condimentum porta. Nunc ex tellus, gravida et imperdiet vitae, ultricies non massa. Praesent accumsan finibus purus et auctor. Integer faucibus sed odio sit amet gravida. Vivamus eleifend, est convallis scelerisque eleifend, risus augue suscipit augue, eu facilisis libero ipsum vel lorem. Nunc consectetur turpis et condimentum consectetur. Donec nec purus sit amet est efficitur cursus.

--- a/content/home/datasets.md
+++ b/content/home/datasets.md
@@ -1,0 +1,77 @@
++++
+# A Projects section created with the Portfolio widget.
+widget = "pages"  # See https://sourcethemes.com/academic/docs/page-builder/
+headless = true  # This file represents a page section.
+active = true  # Activate this widget? true/false
+weight = 65  # Order that this section will appear.
+
+title = "Datasets"
+subtitle = ""
+
+[content]
+  # Page type to display. E.g. project.
+  page_type = "dataset"
+  
+  # Filter toolbar (optional).
+  # Add or remove as many filters (`[[content.filter_button]]` instances) as you like.
+  # To show all items, set `tag` to "*".
+  # To filter by a specific tag, set `tag` to an existing tag name.
+  # To remove toolbar, delete/comment all instances of `[[content.filter_button]]` below.
+  
+  # Default filter index (e.g. 0 corresponds to the first `[[filter_button]]` instance below).
+  filter_default = 0
+  
+  # [[content.filter_button]]
+  #   name = "All"
+  #   tag = "*"
+  
+  # [[content.filter_button]]
+  #   name = "Deep Learning"
+  #   tag = "Deep Learning"
+  
+  # [[content.filter_button]]
+  #   name = "Other"
+  #   tag = "Demo"
+
+[design]
+  # Choose how many columns the section has. Valid values: 1 or 2.
+  columns = "2"
+
+  # Toggle between the various page layout types.
+  #   1 = List
+  #   2 = Compact
+  #   3 = Card
+  #   5 = Showcase
+  view = 3
+
+  # For Showcase view, flip alternate rows?
+  flip_alt_rows = false
+
+[design.background]
+  # Apply a background color, gradient, or image.
+  #   Uncomment (by removing `#`) an option to apply it.
+  #   Choose a light or dark text color by setting `text_color_light`.
+  #   Any HTML color name or Hex value is valid.
+  
+  # Background color.
+  # color = "navy"
+  
+  # Background gradient.
+  # gradient_start = "DeepSkyBlue"
+  # gradient_end = "SkyBlue"
+  
+  # Background image.
+  # image = "background.jpg"  # Name of image in `static/img/`.
+  # image_darken = 0.6  # Darken the image? Range 0-1 where 0 is transparent and 1 is opaque.
+
+  # Text color (true=light or false=dark).
+  # text_color_light = true  
+  
+[advanced]
+ # Custom CSS. 
+ css_style = ""
+ 
+ # CSS class.
+ css_class = ""
++++
+


### PR DESCRIPTION
In development:
- [x] Initial setup of dataset content
- [ ] Create page template with relevant dataset attributes (owner, country, type, size, ...)
- [ ] From this template add all datasets listed in the study-a-thon
- [ ] Dedicated page for the datasets, filterable and sortable on their attributes
- [ ] Link datasets to studies and visa versa

![image](https://user-images.githubusercontent.com/17825660/77822565-3f9ff480-70f4-11ea-8666-c384efd6c1de.png)
